### PR TITLE
Fix vercel function runtime error

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,14 @@
+node_modules
+.git
+.env
+.env.local
+.env.production.local
+.env.development.local
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.DS_Store
+*.log
+coverage
+.vscode
+.idea

--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,5 @@
+import { createRequestHandler } from '@remix-run/vercel'
+
+export default createRequestHandler({
+  build: require('../build/server/remix.js'),
+})

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint --ignore-path .gitignore --cache --cache-location ./node_modules/.cache/eslint .",
     "start": "cross-env NODE_ENV=production node ./server/index.js",
     "typecheck": "tsc",
-    "seed:vehicle-data": "node prisma/seed/vehicleDataWithPatterns.js"
+    "seed:vehicle-data": "node prisma/seed/vehicleDataWithPatterns.js",
+    "vercel-build": "remix vite:build"
   },
   "dependencies": {
     "@ant-design/icons": "^5.4.0",
@@ -25,6 +26,7 @@
     "@remix-run/express": "*",
     "@remix-run/node": "*",
     "@remix-run/react": "*",
+    "@remix-run/vercel": "*",
     "@tanstack/react-query": "^4.36.1",
     "@trpc/client": "^10.45.2",
     "@trpc/react-query": "^10.45.2",

--- a/remix.config.js
+++ b/remix.config.js
@@ -1,0 +1,13 @@
+/** @type {import('@remix-run/dev').AppConfig} */
+export default {
+  ignoredRouteFiles: ["**/.*"],
+  serverModuleFormat: "esm",
+  serverPlatform: "node",
+  tailwind: true,
+  postcss: true,
+  watchPaths: ["./tailwind.config.ts"],
+  // appDirectory: "app",
+  // assetsBuildDirectory: "public/build",
+  // publicPath: "/build/",
+  // serverBuildPath: "build/index.js",
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "buildCommand": "pnpm run vercel-build",
+  "outputDirectory": "build/client",
+  "framework": "remix"
+}


### PR DESCRIPTION
Configure Vercel deployment for Remix applications to resolve "Function Runtimes must have a valid version" error.

The error occurred because Vercel was unable to properly handle the Remix + Vite setup. This PR adds the necessary `vercel.json`, `api/index.js` (using `@remix-run/vercel`), `remix.config.js`, and a dedicated `vercel-build` script to ensure Vercel correctly builds and deploys the Remix application as a serverless function.

---
<a href="https://cursor.com/background-agent?bcId=bc-f2b82c60-9a4f-42f2-85a5-0caca708e493">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f2b82c60-9a4f-42f2-85a5-0caca708e493">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>